### PR TITLE
Fixup favicon service

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <title>markwiemer.com</title>
-    <link rel="shortcut icon" href="/favicon.ico" />
+    <!-- `?` added per https://stackoverflow.com/questions/46163065/github-pages-website-favicon-not-showing -->
+    <link rel="shortcut icon" href="/favicon.ico?" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   </head>
   <body>


### PR DESCRIPTION
Adding a `?` per https://stackoverflow.com/questions/46163065/github-pages-website-favicon-not-showing, likely something with qsps (query string parameters)