### PR TITLE
Fixup favicon.ico by removing Git LFS

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <title>markwiemer.com</title>
-    <!-- `?` added per https://stackoverflow.com/questions/46163065/github-pages-website-favicon-not-showing -->
-    <link rel="shortcut icon" href="/favicon.ico?" />
+    <!-- Tracked as binary, not via Git LFS, to serve via CDN -->
+    <link rel="shortcut icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   </head>
   <body>


### PR DESCRIPTION
Ref https://stackoverflow.com/questions/46163065/github-pages-website-favicon-not-showing